### PR TITLE
Fix #9: Single instance of VideoPlayerActivity

### DIFF
--- a/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
+++ b/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
@@ -34,6 +34,8 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
          */
         fun newInstance(context: Context, url: String, time: String): Intent {
             val intent = Intent(context, VideoPlayerActivity::class.java)
+            // This flag makes sure that there is only one instance of this activity.
+            intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
             intent.putExtra(VIDEO_URL_INTENT_EXTRA, url)
             intent.putExtra(VIDEO_TIME_INTENT_EXTRA, time)
             return intent


### PR DESCRIPTION
Fix #9: Single instance of VideoPlayerActivity

The added flag for intent makes sure that there is only one instance of the activity at any point.

Example: We have multiple activities and we apply this flag on activity `C`.

We open activities like this:
`A` -> `B` -> `C` -> `D` -> `C`
the resultant activity stack will be
`A` -> `B` -> `D` -> `C` where `C` will be reordered by bringing the previous instance to top.

