### PR TITLE
Fix #13: Pause video in background

### DIFF
--- a/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
+++ b/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
@@ -78,6 +78,14 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
         timer.schedule(TimerUpdate(), 0, 1000)
     }
 
+    override fun onPause() {
+        if (::player.isInitialized) {
+            player.pause()
+        }
+        foremWebViewSession.videoPlayerPaused()
+        super.onPause()
+    }
+
     override fun onDestroy() {
         if (::player.isInitialized) {
             player.playWhenReady = false
@@ -88,7 +96,7 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
     }
 
     private fun timeUpdate() {
-        if (::player.isInitialized) {
+        if (::player.isInitialized && player.isPlaying) {
             val milliseconds = player.currentPosition
             val currentTime = (milliseconds / 1000).toString()
             foremWebViewSession.videoPlayerTimerUpdate(currentTime)


### PR DESCRIPTION
Fix #13: Pause video in background

Whenever video is playing if the user minimises the app the the video will get paused and as soon as the app is again in foreground the user will have an option to continue where they left the video.