### PR TITLE
Fix #8: Audio Video Player sync bug fix

### DIFF
--- a/foremwebview/src/main/java/com/forem/webview/AndroidWebViewBridge.kt
+++ b/foremwebview/src/main/java/com/forem/webview/AndroidWebViewBridge.kt
@@ -25,6 +25,9 @@ class AndroidWebViewBridge(
 
     private var timer: Timer? = null
 
+    // This queue maintains the list of all pending actions that needs to be executed by
+    // AudioService. If we do not use this list and audioService is null then some of the actions
+    // may fail.
     private val pendingPodcastActionsQueue: Queue<String> = LinkedList()
 
     // AudioService is initialized when onServiceConnected is executed after/during binding is done.
@@ -33,6 +36,7 @@ class AndroidWebViewBridge(
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             val binder = service as AudioService.AudioServiceBinder
             audioService = binder.service
+            // Once the audio service is bind-ed, execute all pending actions.
             pendingPodcastActionsQueue.forEach {
                 podcastMessage(it)
             }

--- a/foremwebview/src/main/java/com/forem/webview/media/AudioService.kt
+++ b/foremwebview/src/main/java/com/forem/webview/media/AudioService.kt
@@ -55,7 +55,7 @@ class AudioService : LifecycleService() {
         private const val argPodcastUrl = "ARG_PODCAST_URL"
         private const val playbackChannelId = "playback_channel"
         private const val mediaSessionTag = "Forem"
-        private const val playbackNotificationId = 1
+        private const val notificationId = 1
 
         /**
          * Creates a new intent which calls AudioService on main thread.
@@ -102,7 +102,7 @@ class AudioService : LifecycleService() {
             playbackChannelId,
             R.string.app_name,
             R.string.playback_channel_description,
-            playbackNotificationId,
+            notificationId,
             object : PlayerNotificationManager.MediaDescriptionAdapter {
                 override fun getCurrentContentTitle(player: Player): String {
                     return episodeName ?: getString(R.string.app_name)
@@ -211,7 +211,6 @@ class AudioService : LifecycleService() {
      * @param audioUrl the url of the podcast.
      * @param seconds starting time of the padcast.
      */
-    @MainThread
     fun play(audioUrl: String?, seconds: String?) {
         if (currentPodcastUrl != audioUrl) {
             currentPodcastUrl = audioUrl
@@ -227,6 +226,10 @@ class AudioService : LifecycleService() {
     @MainThread
     fun pause() {
         player?.playWhenReady = false
+    }
+
+    fun clearNotification() {
+        player?.release()
     }
 
     /**

--- a/foremwebview/src/main/res/values/strings.xml
+++ b/foremwebview/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">ForemWebView</string>
+  <string name="app_name">Forem Library</string>
   <string name="playback_channel_description">Podcast Player</string>
   <string name="send_email_with">Send email with…</string>
   <string name="select_picture">Select picture</string>


### PR DESCRIPTION
Fix #8: Audio Video Player sync bug fix

# Problems before this PR

## Problem 1

1. Open any podcast
2. Play the podcast
3. Terminate the podcast by clicking `X` in bottom-right corner
4. Notice that notification is still visible

**Solution**

Added `clearNotification` function in `AudioService` which releases the notification and this gets called when `terminate` action is executed.

## Problem 2

1. Open any podcast
2. Play the podcast
3. Terminate the podcast by clicking `X` in bottom-right corner
4. Now again play the same podcast without leaving the page
5. Notice it will not play

**Solution**

The exact reason for this failure is that when we click `play` again in step-4 three actions get executed `load`, `play`, `metadata` and all of these gets called instantly. 
But `load` action is responsible for assigning value to `audioService` which is null before these commands and assigning this values takes some time because its a service connection. Meanwhile because the `audioService` is null the `play` and `metadata` actions fails.
To fix this, whenever actions dependent on `AudioService` fails we add that action to a queue: `pendingPodcastActionsQueue`.
And again when the `audioService` is assigned a value inside `onServiceConnected` we execute all pending actions from `pendingPodcastActionsQueue`, thus fixing the issue.

## Problem 3

1. Open the app
2. Go to podcasts
3. Play one of the podcasts
4. Go back to home page
5. Go to Videos
6. Play one of the videos
7. Video player won't work

**Solution**

Once the above issues were fixed, as soon as we try playing the video using `playVideo` function in `AndroidWebViewBridge` we simply `pause` the audio service and thus making it possible for VideoPlayerActivity to play the video.


