### PR TITLE
Fix #16: Added full screen support for Video Player Activity

### DIFF
--- a/foremwebview/src/main/AndroidManifest.xml
+++ b/foremwebview/src/main/AndroidManifest.xml
@@ -6,8 +6,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.INTERNET" />
 
-  <application
-    android:supportsRtl="true">
+  <application android:supportsRtl="true">
     <activity
       android:name=".video.VideoPlayerActivity"
       android:configChanges="orientation|screenSize|layoutDirection" />

--- a/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
+++ b/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.Window
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import com.forem.webview.ForemWebViewSession
 import com.forem.webview.R
@@ -49,6 +51,12 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        this.window.setFlags(
+            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+            WindowManager.LayoutParams.FLAG_FULLSCREEN
+        );
 
         setContentView(R.layout.video_player_activity)
 


### PR DESCRIPTION
Fix #16: Added full screen support for Video Player Activity

I tried using `FullScreenActivity` which android provides by default but that in turn dependent on its own color scheme which can be a problem because if this library is getting used in some other app then their color-scheme might be different.

As a result I have written kotlin code such that it does work for full-screen and also keeps the flexibility to work with any theme.