### PR TITLE
Release 1.0.11 [Might Fail]

### DIFF
--- a/foremwebview/build.gradle
+++ b/foremwebview/build.gradle
@@ -4,6 +4,7 @@ plugins {
   id 'maven-publish'
 }
 ext{
+  version_code = 11
   version_name = "1.0.11"
 }
 
@@ -13,7 +14,7 @@ android {
   defaultConfig {
     minSdk 21
     targetSdk 31
-    versionCode 10
+    versionCode version_code
     versionName "$version_name"
 
     buildConfigField("String", "ANDROID_BRIDGE", "\"AndroidBridge\"")

--- a/foremwebview/build.gradle
+++ b/foremwebview/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'maven-publish'
 }
 ext{
-  version_name = "1.0.10"
+  version_name = "1.0.11"
 }
 
 android {


### PR DESCRIPTION
Creating Release 1.0.11

- This release might fail because we have used `version_name` and `version_code` as variable and not sure if it will work with jitpack correctly.