### PR TITLE
Fix #27: Removed injected JS code for forem meta data

### DIFF
--- a/foremwebview/src/main/java/com/forem/webview/AndroidWebViewBridge.kt
+++ b/foremwebview/src/main/java/com/forem/webview/AndroidWebViewBridge.kt
@@ -48,19 +48,6 @@ class AndroidWebViewBridge(
     }
 
     /**
-     * Function which gets called once the webview has fully loaded a valid forem instance which
-     * contains the details of forem like name, logo, etc.
-     *
-     * @param foremMetaDataJsonObject an object which contains meta data of forem.
-     */
-    @JavascriptInterface
-    fun processForemMetaData(foremMetaDataJsonObject: String) {
-        var foremMetaDataMap: Map<String, String> = HashMap()
-        foremMetaDataMap = Gson().fromJson(foremMetaDataJsonObject, foremMetaDataMap.javaClass)
-        webViewClient.foremMetaDataReceived(foremMetaDataMap)
-    }
-
-    /**
      * Function which gets called by website when an error occurs.
      *
      * @param errorTag tag required for log message.

--- a/foremwebview/src/main/java/com/forem/webview/ForemWebViewClient.kt
+++ b/foremwebview/src/main/java/com/forem/webview/ForemWebViewClient.kt
@@ -13,9 +13,10 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.browser.customtabs.CustomTabsIntent
 import com.google.firebase.messaging.FirebaseMessaging
+import com.google.gson.Gson
 import org.json.JSONObject
 import java.net.URL
-import java.util.Locale
+import java.util.*
 
 /**
  * Class which extends WebViewClient to override all functions and implement custom functionalities
@@ -43,6 +44,8 @@ class ForemWebViewClient(
 
     private var token: String? = null
 
+    private var foremMetaDataResult: String? = null
+
     init {
         setBaseUrl(originalUrl)
     }
@@ -54,24 +57,6 @@ class ForemWebViewClient(
      */
     fun setBaseUrl(baseUrl: String) {
         this.baseUrl = baseUrl
-    }
-
-    /**
-     * Function called via [AndroidWebViewBridge] when it successfully fetches the meta data of
-     * forem instance.
-     *
-     * @param foremMetaDataMap is a map of forem related meta data.
-     */
-    fun foremMetaDataReceived(foremMetaDataMap: Map<String, String>) {
-        if (UrlChecks.checkUrlIsCorrect(baseUrl)) {
-            val host = URL(baseUrl).host
-            val foremHomePageUrl = UrlChecks.checkAndAppendHttpsToUrl(host)
-            updateForemData(
-                foremHomePageUrl,
-                foremMetaDataMap["title"] ?: "",
-                foremMetaDataMap["logo"] ?: ""
-            )
-        }
     }
 
     /**
@@ -129,33 +114,8 @@ class ForemWebViewClient(
         onPageFinish()
         view.visibility = View.VISIBLE
 
-        if (needsForemMetaData) {
-            // This javascript function triggers the [processForemMetaData] function in
-            // [AndroidWebViewBridge]. This is needed to get the forem name and logo.
-            val fetchMetaDataJSFunction =
-                """
-                    javascript:window.${BuildConfig.ANDROID_BRIDGE}.processForemMetaData((
-                    function (){
-                        var metas = document.getElementsByTagName('meta');
-                        let foremMetaData = new Map();
-                        for (var i=0; i<metas.length; i++) {
-                            if (metas[i].getAttribute("property") == "forem:name") {
-                                let title = metas[i].getAttribute("content");
-                                foremMetaData.set("title", title);
-                            }
-                            else if (metas[i].getAttribute("property") == "forem:logo") {
-                                let logo = metas[i].getAttribute("content");
-                                foremMetaData.set("logo", logo);
-                            }
-                        }
-                        var obj = Object.fromEntries(foremMetaData);
-                        var jsonString = JSON.stringify(obj);
-                        return jsonString;
-                    }
-                    )() );
-                """.trimIndent()
-
-            view.loadUrl(fetchMetaDataJSFunction)
+        if (needsForemMetaData && foremMetaDataResult == null) {
+            getInstanceMetadata()
         }
         super.onPageFinished(view, url)
     }
@@ -168,6 +128,42 @@ class ForemWebViewClient(
                     registerDevice()
                 }
             }
+        }
+    }
+
+    private fun getInstanceMetadata() {
+        val javascript = "window.ForemMobile?.getInstanceMetadata()"
+        webView.post {
+            webView.evaluateJavascript(javascript) {
+                if (!it.isNullOrEmpty() && !it.equals("null")) {
+                    foremMetaDataResult = it
+                    processForemMetaData(it)
+                }
+                return@evaluateJavascript
+            }
+        }
+    }
+
+    private fun processForemMetaData(metaDataJSONStribg: String) {
+        val foremMetaData = metaDataJSONStribg
+            .replace("\"{", "{")
+            .replace("}\"", "}")
+            .replace("\\\"", "\"")
+        val jsonObject = JSONObject(foremMetaData)
+        var foremMetaDataMap: Map<String, String> = HashMap()
+        foremMetaDataMap = Gson().fromJson(jsonObject.toString(), foremMetaDataMap.javaClass)
+        foremMetaDataReceived(foremMetaDataMap)
+    }
+
+    private fun foremMetaDataReceived(foremMetaDataMap: Map<String, String>) {
+        if (UrlChecks.checkUrlIsCorrect(baseUrl)) {
+            val host = URL(baseUrl).host
+            val foremHomePageUrl = UrlChecks.checkAndAppendHttpsToUrl(host)
+            updateForemData(
+                foremHomePageUrl,
+                foremMetaDataMap["name"] ?: "",
+                foremMetaDataMap["logo"] ?: ""
+            )
         }
     }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments. Force-push commit PRs will mostly
     get closed directly.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem-android/blob/develop/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Earlier we were injecting runtime JS code in android app webview using `WebViewClient` so that we can get meta-data like `forem-name`, `logo` and `domain`.  This is not very safe therefore the plan was to shift this code to web-codebase. 

On further inspection of web-codebase it was identified that a function was already introduced in https://github.com/forem/forem/pull/15212/files i.e, `getInstanceMetadata`.

In this PR I have called that function and removed the injected JS code.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #27 
- Closes #27 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI changes
_If your PR includes UI changes, please share before/after screenshots or videos for comparison._

N/A

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested._

N/A

## Added/updated tests?

- [ ] Yes
- [] No, and this is purely optimisation and does not need any test case.
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://giphy.com/clips/southpark-season-8-south-park-episode-12-8VDO7Fy2PFohfdAnpJ)
