### PR TITLE
Fix #25: Fixed singleton instance of ForemWebViewSession

### DIFF
--- a/foremwebview/src/main/java/com/forem/webview/ForemWebViewSession.kt
+++ b/foremwebview/src/main/java/com/forem/webview/ForemWebViewSession.kt
@@ -6,27 +6,27 @@ import android.util.Log
  * Helper class to play and pause video in [VideoPlayerActivity] and send that information to
  * website.
  */
-class ForemWebViewSession {
+class ForemWebViewSession private constructor() {
 
-    /** The [AndroidWebViewBridge] instance required to call javascript interface functions. */
-    var androidWebViewBridge: AndroidWebViewBridge? = null
+    companion object {
+        @Volatile
+        private lateinit var instance: ForemWebViewSession
 
-    private var instance: ForemWebViewSession? = null
-
-    /**
-     * Function which creates a new instance of this class or shares the old instance.
-     *
-     * @return instance of [ForemWebViewSession].
-     */
-    fun getInstance(): ForemWebViewSession? {
-        if (instance == null) {
-            synchronized(ForemWebViewSession::class.java) {
-                if (instance == null) {
+        /** Returns the single instance of [ForemWebViewSession]. */
+        fun getInstance(): ForemWebViewSession {
+            synchronized(this) {
+                if (!::instance.isInitialized) {
                     instance = ForemWebViewSession()
                 }
+                return instance
             }
         }
-        return instance
+    }
+
+    private var androidWebViewBridge: AndroidWebViewBridge? = null
+
+    fun setAndroidWebViewBridge(androidWebViewBridge: AndroidWebViewBridge) {
+        this.androidWebViewBridge = androidWebViewBridge
     }
 
     /** Gets called whenever the video gets paused or the [VideoPlayerActivity] is destroyed. */

--- a/foremwebview/src/main/java/com/forem/webview/WebViewFragment.kt
+++ b/foremwebview/src/main/java/com/forem/webview/WebViewFragment.kt
@@ -179,8 +179,8 @@ class WebViewFragment : Fragment(), FileChooserListener {
         webViewBridge = AndroidWebViewBridge(this.requireActivity(), webViewClient)
         webView!!.addJavascriptInterface(webViewBridge, BuildConfig.ANDROID_BRIDGE)
 
-        foremWebViewSession = ForemWebViewSession().getInstance()!!
-        foremWebViewSession.androidWebViewBridge = webViewBridge
+        foremWebViewSession = ForemWebViewSession.getInstance()
+        foremWebViewSession.setAndroidWebViewBridge(webViewBridge)
 
         // WebView Chrome Client
         webView!!.webChromeClient = ForemWebChromeClient(fileChooserListener = this)

--- a/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
+++ b/foremwebview/src/main/java/com/forem/webview/video/VideoPlayerActivity.kt
@@ -29,7 +29,7 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
         /**
          * Creates a new instance of intent for [VideoPlayerActivity].
          *
-         * @param content the source activity context.
+         * @param context the source activity context.
          * @param url the video which needs to be played.
          * @param time the time at video the video should start from.
          * @return the intent for [VideoPlayerActivity] with extras.
@@ -47,7 +47,9 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
     private lateinit var player: SimpleExoPlayer
     private val timer = Timer()
 
-    private lateinit var foremWebViewSession: ForemWebViewSession
+    private val foremWebViewSession: ForemWebViewSession by lazy {
+        ForemWebViewSession.getInstance()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,14 +61,6 @@ class VideoPlayerActivity : AppCompatActivity(), Player.Listener {
         );
 
         setContentView(R.layout.video_player_activity)
-
-        val foremWebViewSessionInstance = ForemWebViewSession().getInstance()
-        if (foremWebViewSessionInstance == null) {
-            finish()
-            return
-        } else {
-            foremWebViewSession = foremWebViewSessionInstance
-        }
 
         val playerView = findViewById<PlayerView>(R.id.player_view)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments. Force-push commit PRs will mostly
     get closed directly.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem-android/blob/develop/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes two bugs, both of which happens when we start watching a video and close the video:
1. After closing the video, he icon in webview is not updated to `Play` instead it shows `Pause`.
2. If we again start the video, it will start again and will not continue from where the user left the video last time.

Both the above issues have been fixed now.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #25 
- Closes #25 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

N/A

### UI changes
_If your PR includes UI changes, please share before/after screenshots or videos for comparison._

N/A

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested._

N/A

## Added/updated tests?

- [ ] Yes
- [x] No
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
